### PR TITLE
Enable colors option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,4 @@ preexec() {
 to your zshrc.
 
 ## Configuration
-Edit `config.h` and uncomment the line with the girl type you want.
-
-## Todo
-- [ ] Add `config.h` option to enable/disable colors
+Edit `config.h` and uncomment the line with the girl type you want. You can also disable colors by changing the `COLORIZE` define from 1 to 0.

--- a/config.h
+++ b/config.h
@@ -4,6 +4,9 @@
 #define BLUE "\033[36m"
 #define NORMAL "\033[0m"
 
+//change 1 to 0 to disable colors
+#define COLORIZE 1
+
 //#define STRINGS "tsundere"
 //#define STRINGS "imouto"
 //#define STRINGS "maid"

--- a/flirt.c
+++ b/flirt.c
@@ -27,7 +27,9 @@ int main() {
 	srand(time(NULL) ^ (getpid() << 16));
 
 	//select a random color and a random string
-	const char* COLOR = colors[rand() % 4];
+	const char* COLOR;
+	if (COLORIZE) { COLOR = colors[rand() % 4]; }
+	else { COLOR = NORMAL; }
 	const char* str = strings[rand() % 3];
 
 	//print the string in the random color


### PR DESCRIPTION
I'm not sure if this is what you meant with the todo but I had a few minutes to spare so I tried implementing it. It works as far as my testing goes.

That being said, I'm starting to wonder about more in-depth configuration options like adding more colors, specifying which colors to use, adding girl archetypes, more lines for each archetypes and maybe even using multiple archetypes at once. I'm not exactly an expert in C though so idk how much of these ideas are things that can be put mostly in `config.h` #defines and how much would be too complicated and instead should be placed strictly into `flirt.c`.