### PR TITLE
Modified handling of archetypes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ preexec() {flirt;}
 ```
 to your zshrc.
 
+### Fish
+Write a function using `fish_preexec`:
+```fish
+function precmd_flirt --on-event fish_preexec
+    flirt;
+end
+```
+and then save it for future sessions:
+```fish
+funcsave precmd_flirt
+```
+
 ## Todo
 - [x] Add `config.h` option to enable/disable colors
   - Done by [@Kusoneko](https://github.com/Kusoneko)

--- a/config.h
+++ b/config.h
@@ -5,8 +5,8 @@
 #define BLUE "\033[36m"
 #define NORMAL "\033[0m"
 
-//#define STRINGS "tsundere"
-//#define STRINGS "imouto"
-//#define STRINGS "maid"
-//#define STRINGS "onee"
-//#define STRINGS "kouhai"
+//#define TSUNDERE
+//#define IMOUTO
+//#define MAID
+//#define ONEE
+//#define KOUHAI

--- a/flirt.c
+++ b/flirt.c
@@ -1,65 +1,38 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
-#include <unistd.h>
 #include "config.h"
 
 int main() {
-	const int len = 0
-#ifdef TSUNDERE
-		+ 3
-#endif
-#ifdef IMOUTO
-		+ 3
-#endif
-#ifdef MAID
-		+ 3
-#endif
-#ifdef ONEE
-		+ 3
-#endif
-#ifdef KOUHAI
-		+ 3
-#endif
-	;
-
 	const char* colors[] = { RED, GREEN, YELLOW, BLUE };
 
 	const char* strings[] = {
-#ifdef TSUNDERE
-		"It's not like I wanted to do it for you or anything.",
-		"I'm not doing this for you again.",
-		"Ugh, what a bother."
-#endif
-#ifdef IMOUTO
-		"I'll take care of it, onii-chan!",
-		"Onii-chan, don't worry about it.",
-		"Leave it to me, onii-chan!"
-#endif
-#ifdef MAID
-		"As you wish.",
-		"I'll do it for you.",
-		"Yes, master."
-#endif
-#ifdef ONEE
-		"My, my, I'll do it for you.",
-		"I think I can handle it this time.",
-		"I'll make sure this executes properly."
-#endif
-#ifdef KOUHAI
-		"I'll do it, senpai.",
-		"This will be a breeze.",
-		"Senpai, I'll take care of it for you."
-#endif
+#include "strings/tsundere.h"
+#include "strings/imouto.h"
+#include "strings/maid.h"
+#include "strings/onee.h"
+#include "strings/kouhai.h"
 	};
 
+	const int len = 0
+	+ LEN_TSUNDERE
+	+ LEN_IMOUTO
+	+ LEN_MAID
+	+ LEN_ONEE
+	+ LEN_KOUHAI
+	;
+
 	if (len == 0) {
-		fprintf(stderr, "Error: Invalid STRINGS macro. Please edit config.h\n");
+		fprintf(stderr, "Error: No archetypes selected. Please edit config.h\n");
 		return 1;
 	}
 
 	//seed the random number generator
-	srand(time(NULL) ^ (getpid() << 16));
+	//using /dev/random and fopen for a lower footprint than time/getpid
+	//because we don't need unistd.h or time.h
+	FILE* f = fopen("/dev/random", "rb");
+	int seed;
+	fread(&seed, sizeof(int), 1, f);
+	srand(seed);
 
 	//select a random color and a random string
 	const char* COLOR;

--- a/flirt.c
+++ b/flirt.c
@@ -5,45 +5,55 @@
 #include "config.h"
 
 int main() {
+	const int len = 0
+#ifdef TSUNDERE
+		+ 3
+#endif
+#ifdef IMOUTO
+		+ 3
+#endif
+#ifdef MAID
+		+ 3
+#endif
+#ifdef ONEE
+		+ 3
+#endif
+#ifdef KOUHAI
+		+ 3
+#endif
+	;
+
 	const char* colors[] = { RED, GREEN, YELLOW, BLUE };
-	
-	const char* tsundere_strings[] = {
+
+	const char* strings[] = {
+#ifdef TSUNDERE
 		"It's not like I wanted to do it for you or anything.",
 		"I'm not doing this for you again.",
 		"Ugh, what a bother."
-	};
-	
-	const char* imouto_strings[] = {
+#endif
+#ifdef IMOUTO
 		"I'll take care of it, onii-chan!",
 		"Onii-chan, don't worry about it.",
 		"Leave it to me, onii-chan!"
-	};
-	
-	const char* maid_strings[] = {
+#endif
+#ifdef MAID
 		"As you wish.",
 		"I'll do it for you.",
 		"Yes, master."
-	};
-	
-	const char* onee_strings[] = {
+#endif
+#ifdef ONEE
 		"My, my, I'll do it for you.",
 		"I think I can handle it this time.",
 		"I'll make sure this executes properly."
-	};
-	
-	const char* kouhai_strings[] = {
+#endif
+#ifdef KOUHAI
 		"I'll do it, senpai.",
 		"This will be a breeze.",
 		"Senpai, I'll take care of it for you."
+#endif
 	};
 
-	//select the array of strings based on the STRINGS macro
-	const char** strings;
-	if (STRINGS == "tsundere") { strings = tsundere_strings; }
-	else if (STRINGS == "imouto") { strings = imouto_strings; }
-	else if (STRINGS == "maid") { strings = maid_strings; }
-	else if (STRINGS == "onee") { strings = onee_strings; }
-	else if (STRINGS == "kouhai") { strings = kouhai_strings; } else {
+	if (len == 0) {
 		fprintf(stderr, "Error: Invalid STRINGS macro. Please edit config.h\n");
 		return 1;
 	}
@@ -59,7 +69,7 @@ int main() {
 		COLOR= NORMAL;
 	#endif
 
-	const char* str = strings[rand() % 3];
+	const char* str = strings[rand() % len];
 	//print the string in the random color
 	printf("%s%s%s\n", COLOR, str, NORMAL);
 

--- a/strings/imouto.h
+++ b/strings/imouto.h
@@ -1,0 +1,8 @@
+#ifdef IMOUTO
+#define LEN_IMOUTO 3
+		"I'll take care of it, onii-chan!",
+		"Onii-chan, don't worry about it.",
+		"Leave it to me, onii-chan!",
+#else
+#define LEN_IMOUTO 0
+#endif

--- a/strings/kouhai.h
+++ b/strings/kouhai.h
@@ -1,0 +1,8 @@
+#ifdef KOUHAI
+#define LEN_KOUHAI 3
+"I'll do it, senpai.",
+"This will be a breeze.",
+"Senpai, I'll take care of it for you.",
+#else
+#define LEN_KOUHAI 0
+#endif

--- a/strings/maid.h
+++ b/strings/maid.h
@@ -1,0 +1,8 @@
+#ifdef MAID
+#define LEN_MAID 3
+"As you wish.",
+"I'll do it for you.",
+"Yes, master.",
+#else
+#define LEN_MAID 0
+#endif

--- a/strings/onee.h
+++ b/strings/onee.h
@@ -1,0 +1,8 @@
+#ifdef ONEE
+#define LEN_ONEE 3
+"My, my, I'll do it for you.",
+"I think I can handle it this time.",
+"I'll make sure this executes properly.",
+#else
+#define LEN_ONEE 0
+#endif

--- a/strings/tsundere.h
+++ b/strings/tsundere.h
@@ -1,0 +1,8 @@
+#ifdef TSUNDERE
+#define LEN_TSUNDERE 3
+"It's not like I wanted to do it for you or anything.",
+"I'm not doing this for you again.",
+"Ugh, what a bother.",
+#else
+#define LEN_TSUNDERE 0
+#endif


### PR DESCRIPTION
I came across this, while looking for test-code for a toy C compiler I'm writing.

This PR:
- Changed what is used to `srand()`, so that it does not require headers that we aren't already using.
(`/dev/random` exists on practically every UNIX-like, so it is still as portable as before)
- Put each archetype's strings into it's own header, so that they are easier to modify seperately from one another.
- Uncoupled the length of `strings`, to allow for multiple archetypes to be selected at once.
- Created structure such that some archetypes can have more or less strings than others.
- Added installation instructions for `fish`, my shell of choice for most usecases.